### PR TITLE
Add missing version number define in radial wipe effect

### DIFF
--- a/radialWipe/radialwipe.frag
+++ b/radialWipe/radialwipe.frag
@@ -1,7 +1,7 @@
 /***  
     Development by CGVIRUS under GNU GPL Version 3 Licence.
 ***/
-
+#version 130
 
 uniform sampler2D tex;
 varying vec2 uTexCoord;


### PR DESCRIPTION
Effect doesn't work, with the error: `0(51) : error C1115: unable to find compatible overloaded function "texture(sampler2D, vec2)"`
The 2D `texture` overload was introduced with GLSL version 1.30 according to [here](https://community.khronos.org/t/how-can-i-write-vertex-and-fragment-shader-program-to-draw-image-from-texture/74828)
This PR adds the version define so Olive can correctly parse the effect